### PR TITLE
⬆️ Update @sequelize/core to latest version

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -10,6 +10,7 @@ module.exports = {
     ],
   ],
   plugins: [
+    '@babel/plugin-syntax-import-assertions',
     [
       'module-resolver',
       {

--- a/bin/seed/roles.js
+++ b/bin/seed/roles.js
@@ -18,10 +18,10 @@ const { Role } = models;
 // TODO: Refactor to static class
 
 /**
- * @typedef {Object} BaseRole
+ * @typedef { object } BaseRole
  *
- * @property {string} name   - Name of the discord role.
- * @property {string} roleId - Id of the discord role.
+ * @property { string } name   - Name of the discord role.
+ * @property { string } roleId - Id of the discord role.
  */
 
 /**
@@ -29,9 +29,9 @@ const { Role } = models;
  *
  * @description Process all given roles, recursively.
  *
- * @param { BaseRole[] | [][] } roles - A collection of roles to save.
+ * @param   { BaseRole[] | [][] } roles - A collection of roles to save.
  *
- * @returns { Promise<Role>[] }  List off all models instances promises.
+ * @returns { Promise<Role>[] }         List off all models instances promises.
  */
 const processRoles = (roles) =>
   roles.map((role) => {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^10.1.0",
-    "@sequelize/core": "7.0.0-alpha.13",
+    "@sequelize/core": "^7.0.0-alpha.26",
     "chalk": "5.2.0",
     "cli-spinners": "^2.7.0",
     "discord.js": "^14.8.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.21.3",
+    "@babel/plugin-syntax-import-assertions": "^7.20.0",
     "@babel/preset-env": "^7.20.2",
     "@dotenv/cli": "^2.2.2",
     "@jest/globals": "29.5.0",

--- a/src/Classes/Message.js
+++ b/src/Classes/Message.js
@@ -12,8 +12,8 @@ class Message {
    * @constructs Message
    * @description Replaces mustaches interpolations with corresponding given values.
    *
-   * @param { string }                          message        - The message containing mustaches.
-   * @param { Object<string, (number|string)> } interpolations - Map of available interpolations variables.
+   * @param { string }                         message        - The message containing mustaches.
+   * @param { {[key: string]: string|number} } interpolations - Map of available interpolations variables.
    *
    * @example
    * const { message } = new Message(

--- a/src/Models/index.js
+++ b/src/Models/index.js
@@ -53,92 +53,96 @@ const cascadeHooks = {
   onUpdate: 'CASCADE',
 };
 
-db.FollowedMember.hasOne(db.LinkedChannel, cascadeHooks);
-db.LinkedChannel.belongsTo(db.FollowedMember);
+db.FollowedMember.hasOne(db.LinkedChannel, {
+  foreignKey: { ...cascadeHooks },
+});
 
-db.DecisionsTree.hasMany(db.Action, cascadeHooks);
-db.Action.belongsTo(db.DecisionsTree);
+db.DecisionsTree.hasMany(db.Action, { foreignKey: { ...cascadeHooks } });
 
 db.Action.hasOne(db.ActionQuestion, {
-  ...cascadeHooks,
   as: 'Question',
-  foreignKey: 'ActionId',
+  foreignKey: {
+    ...cascadeHooks,
+    name: 'ActionId',
+  },
 });
-db.ActionQuestion.belongsTo(db.Action);
 
 db.ActionQuestion.hasMany(db.ActionQuestionAnswer, {
-  ...cascadeHooks,
   as: 'Answers',
-  foreignKey: 'ActionQuestionId',
+  foreignKey: {
+    ...cascadeHooks,
+    name: 'ActionQuestionId',
+  },
 });
-db.ActionQuestionAnswer.belongsTo(db.ActionQuestion);
 
 db.ActionQuestionAnswer.hasMany(db.ActionQuestionAnswersHasAction, {
-  ...cascadeHooks,
+  foreignKey: { ...cascadeHooks },
   as: 'AnswerActions',
 });
-db.ActionQuestionAnswersHasAction.belongsTo(db.ActionQuestionAnswer);
 
 db.Action.hasMany(db.ActionQuestionAnswersHasAction, {
-  ...cascadeHooks,
+  foreignKey: { ...cascadeHooks },
   as: 'AnswerActions',
 });
-db.ActionQuestionAnswersHasAction.belongsTo(db.Action);
 
 db.Action.hasOne(db.ActionGoto, {
-  ...cascadeHooks,
   as: 'Goto',
-  foreignKey: 'ActionId',
+  foreignKey: {
+    ...cascadeHooks,
+    name: 'ActionId',
+  },
 });
-db.ActionGoto.belongsTo(db.Action);
 
-db.Action.hasOne(db.ActionGoto);
-db.ActionGoto.belongsTo(db.Action, {
-  foreignKey: 'TargetActionId',
-  ...cascadeHooks,
+db.Action.hasOne(db.ActionGoto, {
+  foreignKey: {
+    ...cascadeHooks,
+  },
+  inverse: {
+    as: 'TargetAction',
+  },
 });
 
 db.Action.hasOne(db.ActionPrintMessage, {
-  ...cascadeHooks,
   as: 'PrintMessage',
-  foreignKey: 'ActionId',
+  foreignKey: {
+    ...cascadeHooks,
+    name: 'ActionId',
+  },
 });
-db.ActionPrintMessage.belongsTo(db.Action);
 
 db.Action.hasOne(db.ActionAddRole, {
-  ...cascadeHooks,
   as: 'AddRole',
-  foreignKey: 'ActionId',
+  foreignKey: {
+    ...cascadeHooks,
+    name: 'ActionId',
+  },
 });
-db.ActionAddRole.belongsTo(db.Action);
 
 db.Action.hasOne(db.ActionRemoveRole, {
-  ...cascadeHooks,
   as: 'RemoveRole',
-  foreignKey: 'ActionId',
+  foreignKey: {
+    ...cascadeHooks,
+    name: 'ActionId',
+  },
 });
-db.ActionRemoveRole.belongsTo(db.Action);
 
 db.Action.hasOne(db.ActionPromptFile, {
-  ...cascadeHooks,
   as: 'PromptFile',
-  foreignKey: 'ActionId',
-});
-db.ActionPromptFile.belongsTo(db.Action, {
-  as: 'Action',
+  foreignKey: {
+    ...cascadeHooks,
+    name: 'ActionId',
+  },
 });
 
 db.ActionPromptFile.hasMany(db.ActionPromptFileHasAction, {
-  ...cascadeHooks,
+  foreignKey: { ...cascadeHooks },
   as: 'Actions',
 });
-db.ActionPromptFileHasAction.belongsTo(db.ActionPromptFile);
 
 db.Action.hasMany(db.ActionPromptFileHasAction, {
-  ...cascadeHooks,
+  foreignKey: { ...cascadeHooks },
   as: 'Actions',
 });
-db.ActionPromptFileHasAction.belongsTo(db.Action);
 
 db.ActionPromptFile.belongsToMany(db.MimeType, {
   as: 'MimeTypes',
@@ -148,24 +152,19 @@ db.MimeType.belongsToMany(db.ActionPromptFile, {
   through: 'Action_PromptFiles_Has_MimeTypes',
 });
 
-db.Role.hasOne(db.ActionAddRole, cascadeHooks);
-db.ActionAddRole.belongsTo(db.Role);
+db.Role.hasOne(db.ActionAddRole, { foreignKey: { ...cascadeHooks } });
 
-db.Role.hasOne(db.ActionRemoveRole, cascadeHooks);
-db.ActionRemoveRole.belongsTo(db.Role);
+db.Role.hasOne(db.ActionRemoveRole, { foreignKey: { ...cascadeHooks } });
 
 db.Action.hasOne(db.FollowedMember, {
   foreignKey: 'CurrentActionId',
 });
-db.FollowedMember.belongsTo(db.Action, {
-  foreignKey: 'CurrentActionId',
+
+db.FollowedMember.hasMany(db.RolesToAddToMember, {
+  foreignKey: { cascadeHooks },
 });
 
-db.FollowedMember.hasMany(db.RolesToAddToMember, cascadeHooks);
-db.RolesToAddToMember.belongsTo(db.FollowedMember);
-
-db.Role.hasMany(db.RolesToAddToMember, cascadeHooks);
-db.RolesToAddToMember.belongsTo(db.Role);
+db.Role.hasMany(db.RolesToAddToMember, { foreignKey: { ...cascadeHooks } });
 
 const loaderSync = Logger.loader(
   { spinner: 'dots', color: 'cyan' },


### PR DESCRIPTION
# Description

This PR updates [`@sequelize/core`](https://github.com/sequelize/sequelize) from [`7.0.0-alpha.13`](https://github.com/sequelize/sequelize/releases/tag/v7.0.0-alpha.13) to [`7.0.0-alpha.26`](https://github.com/sequelize/sequelize/releases/tag/v7.0.0-alpha.26), and updates association file, as [`7.0.0-alpha.26`](https://github.com/sequelize/sequelize/releases/tag/v7.0.0-alpha.26) changes the way `belongsTo` and `hasMany`/`hasOne` works.
> See https://github.com/sequelize/sequelize/issues/16007.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

After updating model relations to latest requirements for sequelize update, I exported generated SQL structure and compared it to the original DB structure. 

Apart of constraints names, both structures ar strictly identical.

**Test Configuration**:

- Bot version: 1.0.2
- Node version: 18.11.0
- NPM Version: 9.6.7

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new lint/execution errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
